### PR TITLE
fix(csp): update CSP to work more consistently with Google Maps

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,20 +3,9 @@
     "browser": true
   },
     "rules": {
-      "quotes": false,
-      "no-underscore-dangle": false,
-      "no-unused-expressions": false,
       "curly": [2, "multi-line"],
-      "strict": false,
-      "no-use-before-define": false,
-      "eqeqeq": false,
       "new-cap": [2, {"capIsNew": false}],
       "dot-notation": [2, {"allowKeywords": false}],
-      "no-console": false,
-      "no-return-assign": false,
-      "no-shadow": false,
-      "comma-dangle": false,
       "camelcase": [2, {"properties": "never"}]
     }
 }
-

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "babel": "5.8.21",
     "browser-sync": "2.8.2",
     "del": "1.2.0",
+    "eslint": "^1.9.0",
     "gulp": "3.9.0",
     "gulp-autoprefixer": "2.3.1",
     "gulp-sass": "2.0.4",

--- a/www/index.html
+++ b/www/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="script-src &apos;self&apos; https://maps.googleapis.com/ https://maps.gstatic.com/ https://mts0.googleapis.com/ http://localhost:35729 &apos;unsafe-inline&apos; &apos;unsafe-eval&apos;">
+  <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://maps.gstatic.com/ https://*.googleapis.com/ http://localhost:35729 'unsafe-inline' 'unsafe-eval'">
   <meta name="format-detection" content="telephone=no">
   <meta name="msapplication-tap-highlight" content="no">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">


### PR DESCRIPTION
Add EsLint to package.json. Fix rules for EsLint 1.x.
Rules are disabled by default in 1.x, so just remove rules instead of marking false.
False now causes eslint to throw a type exception.
Add a basic EditorConfig file.