### PR TITLE
npm3 peerDependency fix + scss compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is purely a demo of Ionic v2.0 alpha and is still in development. **There i
 
 * Clone this repository.
 * Run `npm install --production` on project root.
-* Install the ionic-cli if not already (`npm install -g ionic@alpha`)
+* Install the ionic-cli if not already (`npm install -g ionic@beta`)
 * Run `ionic serve` in project root.
 * Profit
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is purely a demo of Ionic v2.0 alpha and is still in development. **There i
 * Clone this repository.
 * Run `npm install --production` on project root.
 * Install the ionic-cli if not already (`npm install -g ionic@beta`)
+* Install the gulp if not already (`npm install -g gulp`)
 * Run `ionic serve` in project root.
 * Profit
 

--- a/ionic.config.js
+++ b/ionic.config.js
@@ -11,14 +11,14 @@ module.exports = {
   // ex: beforeServe, afterRun, beforePrepare, etc.
   hooks: {
     beforeServe: function(argv) {
-      // var spawn = require('child_process').spawn;
-      // var gulpWatch = spawn('gulp', ['watch']);
-      // gulpWatch.stdout.on('data', function(data) {
-      //   console.log(data);
-      // });
-      // gulpWatch.stderr.on('data', function(data) {
-      //   console.log('gulp watch error: ' + data);
-      // });
+      var spawn = require('child_process').spawn;
+      var gulpWatch = spawn('gulp', ['watch']);
+      gulpWatch.stdout.on('data', function(data) {
+        console.log(data);
+      });
+      gulpWatch.stderr.on('data', function(data) {
+        console.log('gulp watch error: ' + data);
+      });
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,13 @@
     "url": "https://github.com/driftyco/ionic-conference-app.git"
   },
   "dependencies": {
-    "ionic-framework": "2.0.0-alpha.42"
+    "angular2": "^2.0.0-alpha.52",
+    "es6-promise": "^3.0.2",
+    "es6-shim": "^0.33.3",
+    "ionic-framework": "2.0.0-alpha.42",
+    "reflect-metadata": "0.1.2",
+    "rxjs": "5.0.0-alpha.14",
+    "zone.js": "0.5.8"
   },
   "devDependencies": {
     "awesome-typescript-loader": "^0.15.9",


### PR DESCRIPTION
Angular2 needs to be included since it's a peerDepenency of ionic-framework.

Since the latest angular2 54, es6-promise, es6-shim and some more packages need to be included explicit too since they became peerDependencies. See https://github.com/angular/angular/blob/master/CHANGELOG.md for an explanation.

I also enabled the scss compilation, leaving it commented out (even tho it's not a perfect solution) will confuse people that are trying out this app, since there is no scss then.