### PR TITLE
Fixed peer dependencies issue for npm 3.x users

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,14 @@
     "url": "https://github.com/driftyco/ionic-conference-app.git"
   },
   "dependencies": {
-    "ionic-framework": "2.0.0-alpha.42"
+    "angular2": "^2.0.0-alpha.52",
+    "es6-promise": "^3.0.2",
+    "es6-shim": "^0.33.3",
+    "ionic-framework": "2.0.0-alpha.42",
+    "reflect-metadata": "0.1.2",
+    "rxjs": "5.0.0-alpha.14",
+    "zone.js": "0.5.8"
+
   },
   "devDependencies": {
     "awesome-typescript-loader": "^0.15.9",


### PR DESCRIPTION
Angular2 needs to be included in package.json, since it's a peer dependency of ionic-framework and npm 3 does not longer install peer dependencies by itself.

Since the latest angular2 54, es6-promise, es6-shim and some more packages need to be included explicit since they became peer dependencies too See https://github.com/angular/angular/blob/master/CHANGELOG.md for an explanation.