### PR TITLE
Store login status in local storage, demonstrate local storage usage

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -7,15 +7,7 @@
   </ion-toolbar>
 
   <ion-content>
-
-    <ion-list>
-
-      <button ion-item *ngFor="#p of pages" (click)="openPage(p)">
-        <icon item-left [name]="p.icon"></icon>
-        {{p.title}}
-      </button>
-
-    </ion-list>
+    <menu-list id="menu-list"></menu-list>
   </ion-content>
 
 </ion-menu>

--- a/app/app.js
+++ b/app/app.js
@@ -5,43 +5,21 @@ import {TabsPage} from './pages/tabs/tabs';
 import {LoginPage} from './pages/login/login';
 import {SignupPage} from './pages/signup/signup';
 import {TutorialPage} from './pages/tutorial/tutorial';
+import {MenuList} from './pages/menu-list/menu-list';
 
 
 @App({
   templateUrl: 'app.html',
   moduleId: 'build/app.html',
-  providers: [ConferenceData, UserData]
+  providers: [ConferenceData, UserData],
+  directives: [MenuList]
 })
 class ConferenceApp {
-  constructor(app: IonicApp, confData: ConferenceData, config: Config) {
-    this.app = app;
-
+  constructor(confData: ConferenceData, config: Config) {
     // load the conference data
     confData.load();
 
     // We plan to add auth to only show the login page if not logged in
     this.root = TutorialPage;
-
-    // create an list of pages that can be navigated to from the left menu
-    // the left menu only works after login
-    // the login page disables the left menu
-    this.pages = [
-      { title: 'Schedules', component: TabsPage, icon: 'calendar' },
-      { title: 'Login', component: LoginPage, icon: 'log-in' },
-      { title: 'Signup', component: SignupPage, icon: 'person-add' },
-      { title: 'Logout', component: LoginPage, icon: 'log-out' },
-    ];
-  }
-
-  openPage(page) {
-    // find the nav component and set what the root page should be
-    // reset the nav to remove previous pages and only have this page
-    // we wouldn't want the back button to show in this scenario
-    let nav = this.app.getComponent('nav');
-    nav.setRoot(page.component).then(() => {
-      // wait for the root page to be completely loaded
-      // then close the menu
-      this.app.getComponent('leftMenu').close();
-    });
   }
 }

--- a/app/pages/login/login.js
+++ b/app/pages/login/login.js
@@ -1,18 +1,25 @@
 import {IonicApp, Page, NavController} from 'ionic/ionic';
 import {TabsPage} from '../tabs/tabs';
 import {SignupPage} from '../signup/signup';
+import {UserData} from '../../providers/user-data';
 
 
 @Page({
   templateUrl: 'build/pages/login/login.html'
 })
 export class LoginPage {
-  constructor(nav: NavController, app: IonicApp) {
+  constructor(nav: NavController, app: IonicApp, userData: UserData) {
     this.nav = nav;
     this.app = app;
+    this.userData = userData;
   }
 
   login() {
+    this.userData.login();
+    
+    let menuList = this.app.getComponent('menu-list');
+    menuList.updateMenuItems(true);
+
     this.nav.push(TabsPage);
   }
 

--- a/app/pages/menu-list/menu-list.html
+++ b/app/pages/menu-list/menu-list.html
@@ -1,0 +1,6 @@
+<ion-list>
+  <button ion-item *ngFor="#menuItem of menuItems" (click)="openPage(menuItem)" [hidden]="menuItem.hide">
+    <icon item-left [name]="menuItem.icon"></icon>
+    {{menuItem.title}}
+  </button>
+</ion-list>

--- a/app/pages/menu-list/menu-list.js
+++ b/app/pages/menu-list/menu-list.js
@@ -1,0 +1,83 @@
+import {Component, View, NgFor} from 'angular2/core';
+import {IonicApp, Page, NavController, IONIC_DIRECTIVES} from 'ionic/ionic';
+import {TabsPage} from '../tabs/tabs';
+import {SignupPage} from '../signup/signup';
+import {LoginPage} from '../login/login';
+import {UserData} from '../../providers/user-data';
+
+@Component({
+  selector: "menu-list"
+})
+@View({
+  templateUrl: 'build/pages/menu-list/menu-list.html',
+  directives: [IONIC_DIRECTIVES]
+})
+export class MenuList {
+  menuItems: Array<any>;
+
+  constructor(app: IonicApp, userData: UserData) {
+    this.app = app;
+    this.userData = userData;
+
+    // We plan to add auth to only show the login page if not logged in
+
+    // create an list of pages that can be navigated to from the left menu
+    // the left menu only works after login
+    // the login page disables the left menu
+    this.menuItems = [
+      { title: 'Schedules', component: TabsPage, icon: 'calendar', hide: false },
+      { title: 'Login', component: LoginPage, icon: 'log-in', hide: false },
+      { title: 'Signup', component: SignupPage, icon: 'person-add', hide: false },
+      { title: 'Logout', component: LoginPage, icon: 'log-out', hide: true }
+    ];
+
+    this.userData.hasLoggedIn().then((hasLoggedIn) => {
+      this.updateMenuItems(hasLoggedIn);
+    })
+  }
+
+  updateMenuItems(hasLoggedIn) {
+    if (hasLoggedIn) {
+      this._hideMenuItem('Login');
+      this._hideMenuItem('Signup');
+      this._showMenuItem('Logout');
+    } else {
+      this._showMenuItem('Login');
+      this._showMenuItem('Signup');
+      this._hideMenuItem('Logout');
+    }
+  }
+
+  openPage(menuItem) {
+    // find the nav component and set what the root page should be
+    // reset the nav to remove previous pages and only have this page
+    // we wouldn't want the back button to show in this scenario
+    let nav = this.app.getComponent('nav');
+    nav.setRoot(menuItem.component).then(() => {
+      // wait for the root page to be completely loaded
+      // then close the menu
+      this.app.getComponent('leftMenu').close();
+    });
+
+    if (menuItem.title === 'Logout') {
+      this._doLogout();
+    }
+  }
+
+  _hideMenuItem(title) {
+    this._findMenuItemByTitle(title).hide = true;
+  }
+
+  _showMenuItem(title) {
+    this._findMenuItemByTitle(title).hide = false;
+  }
+
+  _findMenuItemByTitle(title) {
+    return this.menuItems.find((menuItem) => menuItem.title === title);
+  }
+
+  _doLogout() {
+    this.userData.logout();
+    this.updateMenuItems(false);
+  }
+}

--- a/app/pages/signup/signup.js
+++ b/app/pages/signup/signup.js
@@ -1,16 +1,24 @@
-import {Page, NavController} from 'ionic/ionic';
+import {IonicApp, Page, NavController} from 'ionic/ionic';
 import {TabsPage} from '../tabs/tabs';
+import {UserData} from '../../providers/user-data';
 
 
 @Page({
   templateUrl: 'build/pages/signup/signup.html'
 })
 export class SignupPage {
-  constructor(nav: NavController) {
+  constructor(nav: NavController, app: IonicApp, userData: UserData) {
     this.nav = nav;
+    this.app = app;
+    this.userData = userData;
   }
 
   signup() {
+    this.userData.login();
+
+    let menuList = this.app.getComponent('menu-list');
+    menuList.updateMenuItems(true);
+
     this.nav.push(TabsPage);
   }
 }

--- a/app/providers/user-data.js
+++ b/app/providers/user-data.js
@@ -1,11 +1,14 @@
 import {Injectable} from 'angular2/core';
+import {Storage, LocalStorage} from 'ionic/ionic';
 
 
 @Injectable()
 export class UserData {
+  HAS_LOGGED_IN: string = 'hasLoggedIn';
 
   constructor() {
     this._favorites = [];
+    this.storage = new Storage(LocalStorage);
   }
 
   hasFavorite(sessionName) {
@@ -23,4 +26,22 @@ export class UserData {
     }
   }
 
+  login(username, password) {
+    this.storage.set(this.HAS_LOGGED_IN, true);
+  }
+
+  signup(username, password) {
+    this.storage.set(this.HAS_LOGGED_IN, true);
+  }
+
+  logout() {
+    this.storage.remove(this.HAS_LOGGED_IN);
+  }
+
+  // return a promise
+  hasLoggedIn() {
+    return this.storage.get(this.HAS_LOGGED_IN).then((value) => {
+      return value;
+    });
+  }
 }


### PR DESCRIPTION
- add a boolean flag to local storage after clicking login or signup
- change the menu list menu item visibility based on has loggedin or not

demonstrate local storage usage for https://github.com/driftyco/ionic-conference-app/issues/54
resolving the issue https://github.com/driftyco/ionic-conference-app/issues/101