### PR TITLE
refresh schedule when user clicks cancel or clear the searchbar

### DIFF
--- a/app/pages/schedule/schedule.html
+++ b/app/pages/schedule/schedule.html
@@ -24,6 +24,7 @@
   <ion-searchbar primary
                  [(ngModel)]="queryText"
                  (keyup)="updateSchedule()"
+                 (clear)="searchbarCleared()"
                  showCancel="true"
                  placeholder="Search">
   </ion-searchbar>

--- a/app/pages/schedule/schedule.js
+++ b/app/pages/schedule/schedule.js
@@ -40,6 +40,16 @@ export class SchedulePage {
     });
   }
 
+  searchbarCleared() {
+    this.queryText = '';
+    this.updateSchedule();
+  }
+
+  searchCancelled() {
+    console.log('searchCancelled', this.queryText);
+    this.updateSchedule();
+  }
+
   openFilter() {
     this.modal.open(ScheduleFilterPage, this.excludeTracks).then(modalRef => {
       modalRef.onClose = (excludeTracks) => {
@@ -73,7 +83,7 @@ export class SchedulePage {
         // close the sliding item and hide the option buttons
         slidingItem.close();
       }, () => {
-        
+
         slidingItem.close();
       });
 


### PR DESCRIPTION
the original issue was https://github.com/driftyco/ionic-conference-app/issues/95
afterthat, clear event callback was implemented in https://github.com/driftyco/ionic2/commit/53dd312b39c508a4c893d3c78d5e082ed12db168

this pull request is just utilize the new callback and refresh the schedule list