### PR TITLE
Windows 10 phone network capabilities

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -66,6 +66,8 @@
   <preference name="SplashScreen" value="screen"/>
   <preference name="orientation" value="portrait"/>
   <preference name="SplashScreenDelay" value="300"/>
+  <preference name="internetClient" value="true"/>
+  <preference name="privateNetworkClientServer" value="true"/>
   <feature name="StatusBar">
     <param name="ios-package" onload="true" value="CDVStatusBar"/>
   </feature>


### PR DESCRIPTION
Without this capabilites the phone will not use the network and the maps will not work.