### PR TITLE
Disable shadow on tutorial

### DIFF
--- a/app/pages/tutorial/tutorial.html
+++ b/app/pages/tutorial/tutorial.html
@@ -1,4 +1,4 @@
-<ion-header>
+<ion-header class="no-shadow">
   <ion-navbar>
     <ion-buttons end *ngIf="showSkip">
       <button (click)="startApp()" primary>Skip</button>

--- a/app/pages/tutorial/tutorial.scss
+++ b/app/pages/tutorial/tutorial.scss
@@ -1,3 +1,8 @@
+.md {
+  .no-shadow::after {
+    content: none;
+  }
+}
 
 .tutorial-page {
   .toolbar-background {


### PR DESCRIPTION
This is just a workaround, but maybe there should be an option like <ion-header no-shadow> but I don't know how to implement that.