### PR TITLE
Remove duplicate ngModel from forms

### DIFF
--- a/app/pages/login/login.html
+++ b/app/pages/login/login.html
@@ -17,7 +17,7 @@
     <form #loginForm="ngForm" novalidate>
       <ion-item>
         <ion-label floating primary>Username</ion-label>
-        <ion-input [(ngModel)]="login.username" ngModel name="username" type="text" #username="ngModel" spellcheck="false" autocapitalize="off" required>
+        <ion-input [(ngModel)]="login.username" name="username" type="text" #username="ngModel" spellcheck="false" autocapitalize="off" required>
         </ion-input>
       </ion-item>
       <p [hidden]="username.valid || submitted == false" danger padding-left>
@@ -26,7 +26,7 @@
 
       <ion-item>
         <ion-label floating primary>Password</ion-label>
-        <ion-input [(ngModel)]="login.password" ngModel name="password" type="password" #password="ngModel" required>
+        <ion-input [(ngModel)]="login.password" name="password" type="password" #password="ngModel" required>
         </ion-input>
       </ion-item>
       <p [hidden]="password.valid || submitted == false" danger padding-left>

--- a/app/pages/signup/signup.html
+++ b/app/pages/signup/signup.html
@@ -17,7 +17,7 @@
     <form #signupForm="ngForm" novalidate>
       <ion-item>
         <ion-label floating primary>Username</ion-label>
-        <ion-input [(ngModel)]="signup.username" ngModel name="username" type="text" #username="ngModel" required>
+        <ion-input [(ngModel)]="signup.username" name="username" type="text" #username="ngModel" required>
         </ion-input>
       </ion-item>
       <p [hidden]="username.valid || submitted == false" danger padding-left>
@@ -26,7 +26,7 @@
 
       <ion-item>
         <ion-label floating primary>Password</ion-label>
-        <ion-input [(ngModel)]="signup.password" ngModel name="password" type="password" #password="ngModel" required>
+        <ion-input [(ngModel)]="signup.password" name="password" type="password" #password="ngModel" required>
         </ion-input>
       </ion-item>
       <p [hidden]="password.valid || submitted == false" danger padding-left>


### PR DESCRIPTION
Pull request #224 added a standalone ngModel to the forms, but since you're already using 2-way binding via ngModel, you don't need to add it again.