### PR TITLE
Fix icon placement for menu items

### DIFF
--- a/src/app/app.template.html
+++ b/src/app/app.template.html
@@ -15,7 +15,7 @@
         Navigate
       </ion-list-header>
       <button ion-item menuClose *ngFor="let p of appPages" (click)="openPage(p)">
-        <ion-icon item-left [name]="p.icon"></ion-icon>
+        <ion-icon left [name]="p.icon"></ion-icon>
         {{p.title}}
       </button>
     </ion-list>
@@ -25,7 +25,7 @@
         Account
       </ion-list-header>
       <button ion-item menuClose *ngFor="let p of loggedOutPages" (click)="openPage(p)">
-        <ion-icon item-left [name]="p.icon"></ion-icon>
+        <ion-icon left [name]="p.icon"></ion-icon>
         {{p.title}}
       </button>
     </ion-list>
@@ -49,7 +49,7 @@
         Navigate
       </ion-list-header>
       <button ion-item menuClose *ngFor="let p of appPages" (click)="openPage(p)">
-        <ion-icon item-left [name]="p.icon"></ion-icon>
+        <ion-icon left [name]="p.icon"></ion-icon>
         {{p.title}}
       </button>
     </ion-list>
@@ -59,7 +59,7 @@
         Account
       </ion-list-header>
       <button ion-item menuClose *ngFor="let p of loggedInPages" (click)="openPage(p)">
-        <ion-icon item-left [name]="p.icon"></ion-icon>
+        <ion-icon left [name]="p.icon"></ion-icon>
         {{p.title}}
       </button>
     </ion-list>


### PR DESCRIPTION
`item-left` changed to `left` to align the icons properly in the menu.