### PR TITLE
Add step to manually create the 'www' folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This is purely a demo of Ionic 2 with TypeScript. It is still in development.
 * Want to use TypeScript? Both the `master` branch and the `typescript` branch now use TypeScript.
 * Run `npm install` from the project root.
 * Install the ionic CLI (`npm install -g ionic`)
+* Create an empty 'www' folder under the project root (`mkdir www`)
 * Run `ionic serve` in a terminal from the project root.
 * Profit
 


### PR DESCRIPTION
Before, when running `ionic serve`, the following error is shown: "There was an error serving your Ionic application: "www" directory cannot be found. Please make sure the working directory is an Ionic project." The 'www' folder was in the .gitignore file, and therefore was not being checked into Git. The simple fix is for the user to manually create an empty 'www' folder.