### PR TITLE
Fixed ionic-app-scripts compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@ionic/app-scripts": "0.0.39",
-    "typescript": "^2.0.3"
+    "typescript": "2.0.9"
   },
   "cordovaPlugins": [
     "cordova-plugin-whitelist",


### PR DESCRIPTION
`^2.0.3` points to Typescript 2.1 which isn't supported by Ionic/App-scripts yet.

This PR solves issues like https://github.com/driftyco/ionic-app-scripts/issues/367