### PR TITLE
fix(): @ionic/storage dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser": "2.2.1",
     "@angular/platform-browser-dynamic": "2.2.1",
     "@angular/platform-server": "2.2.1",
-    "@ionic/storage": "1.1.6",
+    "@ionic/storage": "1.1.7",
     "ionic-angular": "2.0.0-rc.5",
     "ionic-native": "2.2.11",
     "ionicons": "3.0.0",


### PR DESCRIPTION
On Ionic RC4 [CHANGELOG](https://github.com/driftyco/ionic/blob/master/CHANGELOG.md) the @ionic/storage dependency version was updated to 1.1.7, but on ionic-conference-app package.json is in 1.1.6.