### PR TITLE
fix(): side menu highlighting and navigation

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -155,7 +155,7 @@ export class ConferenceApp {
 
     // Tabs are a special case because they have their own navigation
     if (childNav) {
-      if (childNav.getSelected() && childNav.getSelected().root === page.tabName) {
+      if (childNav.getSelected() && childNav.getSelected().root === page.tabComponent) {
         return 'primary';
       }
       return;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -53,7 +53,7 @@ import { UserData } from '../providers/user-data';
     HttpModule,
     IonicModule.forRoot(ConferenceApp, {}, {
       links: [
-        { component: TabsPage, name: 'Tabs', segment: 'tabs' },
+        { component: TabsPage, name: 'TabsPage', segment: 'tabs' },
         { component: SchedulePage, name: 'Schedule', segment: 'schedule' },
         { component: SessionDetailPage, name: 'SessionDetail', segment: 'sessionDetail/:name' },
         { component: ScheduleFilterPage, name: 'ScheduleFilter', segment: 'scheduleFilter' },


### PR DESCRIPTION
navigation: The name of the `TabsPage` link should match the
name being used to navigate.

highlighting: There is no `tabName` property on `PageInterface`.
It should be `tabComponent`.

This PR resolves #379